### PR TITLE
Added a Node cache to all pipelines

### DIFF
--- a/.github/workflows/ecs-linux.yml
+++ b/.github/workflows/ecs-linux.yml
@@ -31,6 +31,9 @@ on:
       lambda_deployment:
         type: boolean
         default: false
+      node_cache:
+        type: string
+        default: ""
     secrets:
       aws_key:
         required: true
@@ -68,6 +71,13 @@ jobs:
         with:
           repository: recipopdev/github-workflows
           path: github-workflows
+
+      - uses: actions/setup-node@v3
+        if: ${{ inputs.node_cache != '' }}
+        id: node-cache
+        with:
+          node-version: 20
+          cache: ${{ inputs.node_cache }}
 
       - name: Copy deployment scripts
         id: deployment-scripts


### PR DESCRIPTION
- Enabled by including `node_cache: "npm"` argument in a project's workflows
- Only caches global package data, not a project's `node_modules`